### PR TITLE
Add mass cleaning commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -219,7 +219,6 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dependencies": {
-        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -287,7 +286,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -15,4 +15,6 @@ export default {
   Leaderboard: Sudoku.leaderboard,
   SubscribeForce: Sudoku.subscribeForce,
   Erase: Sudoku.erase,
+  CleanGuess: Sudoku.cleanAllGuess,
+  TotalDoubt: Sudoku.totalDoubt,
 };

--- a/src/commands/sudoku.js
+++ b/src/commands/sudoku.js
@@ -204,6 +204,52 @@ export const erase = {
   },
 };
 
+export const totalDoubt = {
+  name: "totaldoubt",
+  description: "Transform all played position in guess",
+  async execute(message, args) {
+    const puzzle = await getChannelSudoku(message.channel.id);
+    if (!puzzle) {
+      return message.channel.send("Vous ne jouez pas au Sudoku :(");
+    }
+    try {
+      const newPuzzle = Sudoku.totalDoubt({
+        puzzle,
+        author: message.author.username,
+      });
+      await addSudokuToChannel(message.channel.id, newPuzzle);
+      const attachment = await getSudokuImage(newPuzzle);
+      message.channel.send(":thinking:", attachment);
+    } catch (e) {
+      console.error(e);
+      message.channel.send(e.message);
+    }
+  },
+};
+
+export const cleanAllGuess = {
+  name: "cleanguess",
+  description: "Erase all guess positions",
+  async execute(message, args) {
+    const puzzle = await getChannelSudoku(message.channel.id);
+    if (!puzzle) {
+      return message.channel.send("Vous ne jouez pas au Sudoku :(");
+    }
+    try {
+      const newPuzzle = Sudoku.cleanAllGuess({
+        puzzle,
+        author: message.author.username,
+      });
+      await addSudokuToChannel(message.channel.id, newPuzzle);
+      const attachment = await getSudokuImage(newPuzzle);
+      message.channel.send(":sob:", attachment);
+    } catch (e) {
+      console.error(e);
+      message.channel.send(e.message);
+    }
+  },
+};
+
 export const blame = {
   name: "blame",
   description: "Blame a sudoku play",

--- a/src/sudoku.js
+++ b/src/sudoku.js
@@ -89,6 +89,38 @@ export const erase = ({ puzzle, colChar, rowChar, author }) => {
   });
 };
 
+export const totalDoubt = ({ puzzle, author }) => {
+  return puzzle.map((_) => {
+    return _.map((cell) => {
+      if (cell.initial === true) {
+        return cell;
+      }
+      return {
+        value: cell.value,
+        lastPlayed: cell.value ? true : false,
+        guess: cell.value ? true : false,
+        author,
+      };
+    });
+  });
+};
+
+export const cleanAllGuess = ({ puzzle, author }) => {
+  return puzzle.map((_) => {
+    return _.map((cell) => {
+      if (cell.initial === true) {
+        return cell;
+      }
+      return {
+        value: cell.guess ? null : cell.value,
+        lastPlayed: cell.guess ? true : false,
+        guess: false,
+        author,
+      };
+    });
+  });
+};
+
 export const isPuzzleWinning = (puzzle) => {
   const hasEmptyCell = puzzle.some((rows) =>
     rows.some((cell) => cell.value === null)


### PR DESCRIPTION
to erase all guess :  !cleanguess
(When a guess appear to be wrong after a long path)

to transform all valid cases in guess : !totaldoubt
(When we discover that something is broken at the end, and want to redo it correctly whithout erasing all directly)