### PR TITLE
display invalid numbers

### DIFF
--- a/src/commands/sudoku.js
+++ b/src/commands/sudoku.js
@@ -16,7 +16,7 @@ const getSudokuImage = async (puzzle) => {
     });
     const buffer = await HtmlToImage({
         html,
-        content: { rows: puzzle },
+        content: { rows: Sudoku.showInvalidNumbers(puzzle) },
     });
     const attachment = new MessageAttachment(buffer, "sudoku.png");
     return attachment;

--- a/src/sudoku.html
+++ b/src/sudoku.html
@@ -53,6 +53,9 @@
                 top: 0;
                 right: 0;
             }
+            .invalid {
+                color: red;
+            }
         </style>
     </head>
     <body>
@@ -75,7 +78,7 @@
                     <th class="row-index">{{inc @index}}</th>
                     {{#each this}}
                     <td
-                        class="{{#if this.initial}}initial{{/if}} {{#if this.lastPlayed}}last-played{{/if}} {{#if this.guess}}guess{{/if}}"
+                        class="{{#if this.initial}}initial{{/if}} {{#if this.lastPlayed}}last-played{{/if}} {{#if this.guess}}guess{{/if}} {{#if this.invalid}}invalid{{/if}}"
                     >
                         {{this.value}}
                     </td>

--- a/src/sudoku.js
+++ b/src/sudoku.js
@@ -169,3 +169,66 @@ export const getPuzzleLeaderboard = (puzzle) => {
         return { ...leaderboard, [cell.author]: score + 1 };
     }, {});
 };
+
+const isCellInvalid = (puzzle, indexRow, indexCol, value) => {
+  for (let row = 0; row < 9; row++) {
+    if (
+      indexRow != row &&
+      puzzle[row][indexCol].value &&
+      puzzle[row][indexCol].value === value &&
+      !puzzle[row][indexCol].guess
+    ) {
+      return true;
+    }
+  }
+
+  for (let col = 0; col < 9; col++) {
+    if (
+      indexCol != col &&
+      puzzle[indexRow][col].value &&
+      puzzle[indexRow][col].value === value &&
+      !puzzle[indexRow][col].guess
+    ) {
+      return true;
+    }
+  }
+
+  const cellSquareRow = Math.floor(indexRow / 3);
+  const cellSquareCol = Math.floor(indexCol / 3);
+  for (let row = 0; row < 9; row++) {
+    for (let col = 0; col < 9; col++) {
+      const currentSquareRow = Math.floor(row / 3);
+      const currentSquareCol = Math.floor(col / 3);
+      if (
+        cellSquareRow === currentSquareRow &&
+        cellSquareCol === currentSquareCol
+      ) {
+        if (
+          !(indexCol === col && indexRow === row) &&
+          puzzle[row][col].value &&
+          puzzle[row][col].value === value &&
+          !puzzle[row][col].guess
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+};
+
+export const showInvalidNumbers = (puzzle) => {
+  return puzzle.map((_, indexRow) => {
+    return _.map((cell, indexCol) => {
+      if (cell.initial === true) {
+        return cell;
+      }
+      return {
+        ...cell,
+        invalid:
+          !cell.guess && isCellInvalid(puzzle, indexRow, indexCol, cell.value),
+      };
+    });
+  });
+};


### PR DESCRIPTION
Identify where numbers played are violating the sudoku rules
(It doesn't say if they are write or wrong, and it ignores the guess numbers)

Just display for now, without storing it

It will help to see sooner when someone played a stupid thing and to not continue in a wrong direction

![image](https://user-images.githubusercontent.com/39904906/115047225-9e3f3880-9ed8-11eb-9262-6c0048360cdb.png)
